### PR TITLE
Bug Fix: Endlessly Appending Notifications

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -9,9 +9,11 @@ class NotificationsController < ApplicationController
   end
 
   def update
-    @notifications = policy_scope(Notification)
-    authorize(@notifications)
-    @notifications.update_all(read_at: Time.zone.now)
+    notifications = policy_scope(Notification)
+    cached_ids = notifications.select(:id)
+    authorize(notifications)
+    notifications.update_all(read_at: Time.zone.now)
+    @notifications = Notification.where(id: cached_ids)
 
     respond_to do |format|
       format.js

--- a/app/javascript/plugins/notifications.js
+++ b/app/javascript/plugins/notifications.js
@@ -8,7 +8,7 @@ class Notifications {
 
   setup() {
     this.pollForUpdates();
-    $("[data-behavior='notifications-link']").on("click", this.markAsRead);
+    $("[data-behavior='notifications-link']").on("click", this.getNotificationsAndMarkAsRead);
   }
 
   setPollingTimeout() {
@@ -16,15 +16,15 @@ class Notifications {
   }
 
   pollForUpdates() {
-    this.getNotifications().done(() => this.setPollingTimeout())
+    this.getNotificationsCount().done(() => this.setPollingTimeout())
   }
 
 
-  getNotifications() {
+  getNotificationsCount() {
     return $.get("/notifications.js")
   }
 
-  markAsRead(event) {
+  getNotificationsAndMarkAsRead(event) {
     const url = event.currentTarget.dataset.remoteUrl;
     $.ajax({
       url: url,

--- a/app/javascript/plugins/notifications.js
+++ b/app/javascript/plugins/notifications.js
@@ -25,12 +25,14 @@ class Notifications {
   }
 
   getNotificationsAndMarkAsRead(event) {
-    const url = event.currentTarget.dataset.remoteUrl;
-    $.ajax({
-      url: url,
-      method: "PUT",
-      data: { authenticity_token: $('meta[name="csrf-token"]').attr("content") }
-    });
+    if ( link.getAttribute("aria-expanded") === "false" ) {
+      const url = event.currentTarget.dataset.remoteUrl;
+      $.ajax({
+        url: url,
+        method: "PUT",
+        data: { authenticity_token: $('meta[name="csrf-token"]').attr("content") }
+      });
+    }
   }
 }
 

--- a/app/views/notifications/index.js.erb
+++ b/app/views/notifications/index.js.erb
@@ -1,5 +1,1 @@
 document.querySelector("[data-behavior='unread-count']").innerText = "<%= @notifications.count %>";
-
-<% @notifications.each do |notification| %>
-  document.querySelector("[data-notifications-dropdown]").insertAdjacentHTML("beforeend", "<%=j render notification %>");
-<% end %>

--- a/app/views/notifications/update.js.erb
+++ b/app/views/notifications/update.js.erb
@@ -1,1 +1,5 @@
 document.querySelector("[data-behavior='unread-count']").innerText = "0";
+
+<% @notifications.each do |notification| %>
+  document.querySelector("[data-notifications-dropdown]").insertAdjacentHTML("beforeend", "<%=j render notification %>");
+<% end %>


### PR DESCRIPTION
This PR fixes the bug where notifications would endlessly append to the notifications dropdown in the background.  This is because we were appending unread notifications after every poll request.  This meant that, until the user read the notifications, the same notifications would be appended to the dropdown over and over again.

This PR fixes that issue by only appending notification to the dropdown when the user clicks on the notifications icon to see the dropdown.  This ensures that the notifications only get appended once.

I also updated the notifications.js plugin to only send a request to append unread notifications when the dropdown is in an unopened state.  This means that the request will only be sent when a user goes to open the dropdown.

You'll notice, in the `NotificationsController#update`,  I had to save the ids of all the unread notifications and then use those to find the notifications that were just marked as read.  I believe ActiveRecord was caching the query to find all unread notifications when calling `policy_scope(Notification)`.  However, that query was not being run until the remote javascript file was called.  Because this happens after the notifications have already been updated to marked as read, it was returning (and appending) no notifications.  I had to save the ids first, then run a query to find notifications with those ids before sending them to the javascript file.